### PR TITLE
Add static data fallbacks for community and marketplace pages

### DIFF
--- a/autohub/frontend/src/data/community.json
+++ b/autohub/frontend/src/data/community.json
@@ -1,0 +1,64 @@
+{
+  "posts": [
+    {
+      "id": "p1",
+      "author": "Motor_Head_Max",
+      "avatar": "https://i.pravatar.cc/96?img=11",
+      "content": "Just finished installing the new turbos on my Supra! The power delivery is mind-blowing. Can't wait to hit the dyno next week! What's everyone else working on this weekend?",
+      "image": "https://images.unsplash.com/photo-1493238792000-8113da705763?q=80&w=1600&auto=format&fit=crop",
+      "likes": 254,
+      "comments": 43,
+      "featured": true,
+      "timestamp": "1h ago"
+    },
+    {
+      "id": "p2",
+      "author": "Rally_Master_Ron",
+      "avatar": "https://i.pravatar.cc/96?img=13",
+      "content": "What a blast at the local autocross event! My Subaru WRX performed flawlessly. Managed to shave off 0.5 seconds from my previous best time! Any tips for improving cornering speed?",
+      "image": "https://images.unsplash.com/photo-1503376780353-7e6692767b70?q=80&w=1600&auto=format&fit=crop",
+      "likes": 132,
+      "comments": 18,
+      "featured": false,
+      "timestamp": "3h ago"
+    },
+    {
+      "id": "p3",
+      "author": "Classic_Rides_Mia",
+      "avatar": "https://i.pravatar.cc/96?img=45",
+      "content": "Restoring this vintage Ford Mustang Fastback. Found some original parts today! It's a slow process but incredibly rewarding. Any other classic car restorers out there?",
+      "image": "https://images.unsplash.com/photo-1525609004556-c46c7d6cf023?q=80&w=1600&auto=format&fit=crop",
+      "likes": 201,
+      "comments": 29,
+      "featured": false,
+      "timestamp": "5h ago"
+    },
+    {
+      "id": "p4",
+      "author": "Drift_King_Hiro",
+      "avatar": "https://i.pravatar.cc/96?img=5",
+      "content": "Practicing some tandem drifts with the crew tonight. Getting better at transitions! Always learning. Check out the drone footage from last session!",
+      "image": "https://images.unsplash.com/photo-1502877338535-766e1452684a?q=80&w=1600&auto=format&fit=crop",
+      "likes": 176,
+      "comments": 22,
+      "featured": false,
+      "timestamp": "1d ago"
+    },
+    {
+      "id": "p5",
+      "author": "Custom_Paint_Kai",
+      "avatar": "https://i.pravatar.cc/96?img=23",
+      "content": "New custom paint job on a client's show car! This metallic flake really pops in the sun. What are your favorite custom paint colors?",
+      "image": "https://images.unsplash.com/photo-1492144534655-ae79c964c9d7?q=80&w=1600&auto=format&fit=crop",
+      "likes": 93,
+      "comments": 12,
+      "featured": false,
+      "timestamp": "1d ago"
+    }
+  ],
+  "stats": [
+    { "value": "15,000", "label": "Total Members", "color": "#8B5CF6" },
+    { "value": "2,345", "label": "Active Posts", "color": "#EF4444" },
+    { "value": "120", "label": "New Today", "color": "#22C55E" }
+  ]
+}

--- a/autohub/frontend/src/data/listingDetails.json
+++ b/autohub/frontend/src/data/listingDetails.json
@@ -1,0 +1,34 @@
+{
+  "listing": {
+    "id": "civic-2020-type-r",
+    "title": "Custom 2020 Honda Civic Type R - Heavily Modified",
+    "price": "R 745,494.63",
+    "location": "Cape Town, South Africa",
+    "condition": "Used",
+    "make": "Honda",
+    "model": "Civic Type R",
+    "year": 2020,
+    "description": "This meticulously maintained 2020 Honda Civic Type R is a true enthusiast's dream, boasting an extensive list of high-performance modifications and a stunning exterior. With only one owner and a clean title, this car has been babied and regularly serviced. It's built for both track performance and daily driving comfort, delivering an exhilarating experience every time. The engine has been professionally tuned and all modifications were installed by certified technicians. Ready for its next adventure, whether it's conquering winding roads or turning heads at car meets.",
+    "images": [
+      "https://images.unsplash.com/photo-1606665813985-1dbd8f7f6b31?q=80&w=1600&auto=format&fit=crop"
+    ],
+    "specs": [
+      { "label": "Make", "value": "Honda" },
+      { "label": "Model", "value": "Civic Type R" },
+      { "label": "Year", "value": "2020" },
+      { "label": "Mileage", "value": "—" },
+      { "label": "Engine", "value": "2.0L Turbo" },
+      { "label": "Transmission", "value": "6-Speed Manual" }
+    ]
+  },
+  "related": [
+    { "id": "r1", "title": "2022 Ford Mustang GT Premium", "price": "R 684,083.41", "image": "https://images.unsplash.com/photo-1525609004556-c46c7d6cf023?q=80&w=1600&auto=format&fit=crop" },
+    { "id": "r2", "title": "2018 Porsche 911 Carrera S", "price": "R 1,490,989.25", "image": "https://images.unsplash.com/photo-1502877338535-766e1452684a?q=80&w=1600&auto=format&fit=crop" },
+    { "id": "r3", "title": "2021 BMW M3 Competition", "price": "R 1,262,955.60", "image": "https://images.unsplash.com/photo-1555215695-3004980ad54e?q=80&w=1600&auto=format&fit=crop" },
+    { "id": "r4", "title": "2017 Nissan GT-R Black Edition", "price": "R 1,666,399.75", "image": "https://images.unsplash.com/photo-1525609004556-c46c7d6cf023?q=80&w=1600&auto=format&fit=crop" },
+    { "id": "r5", "title": "1991 Mazda RX-7 FC3S", "price": "R 491,149.40", "image": "https://images.unsplash.com/photo-1511394181419-16f2bb1b0a42?q=80&w=1600&auto=format&fit=crop" },
+    { "id": "r6", "title": "2015 Audi RS7 Sportback", "price": "R 2,017,220.75", "image": "https://images.unsplash.com/photo-1523986371872-9d3ba2e2f642?q=80&w=1600&auto=format&fit=crop" },
+    { "id": "r7", "title": "2020 Mercedes-AMG C63 S", "price": "R 1,192,791.40", "image": "https://images.unsplash.com/photo-1519638399535-1b036603ac77?q=80&w=1600&auto=format&fit=crop" },
+    { "id": "r8", "title": "2022 Subaru WRX STI Limited", "price": "R 798,117.78", "image": "https://images.unsplash.com/photo-1503376780353-7e6692767b70?q=80&w=1600&auto=format&fit=crop" }
+  ]
+}

--- a/autohub/frontend/src/data/marketplace.json
+++ b/autohub/frontend/src/data/marketplace.json
@@ -1,0 +1,56 @@
+{
+  "featured": [
+    {
+      "id": "f1",
+      "title": "1969 Ford Mustang Fastback",
+      "description": "Iconic classic muscle car, meticulously restored with a powerful V8 engine. A true head-turner.",
+      "price": "R 1,315,578.75",
+      "image": "https://images.unsplash.com/photo-1519681393784-d120267933ba?q=80&w=1600&auto=format&fit=crop"
+    },
+    {
+      "id": "f2",
+      "title": "2020 Honda Civic Type R",
+      "description": "This meticulously maintained 2020 Honda Civic Type R is a true enthusiast's dream, boasting high-performance modifications.",
+      "price": "R 745,494.63",
+      "image": "https://images.unsplash.com/photo-1606665813985-1dbd8f7f6b31?q=80&w=1600&auto=format&fit=crop"
+    },
+    {
+      "id": "f3",
+      "title": "Jeep Wrangler Rubicon Unlimited",
+      "description": "Fully outfitted off-road beast. Ready for any adventure.",
+      "price": "R 857,757.35",
+      "image": "https://images.unsplash.com/photo-1519638399535-1b036603ac77?q=80&w=1600&auto=format&fit=crop"
+    },
+    {
+      "id": "f4",
+      "title": "Audi R8 V10 plus",
+      "description": "Every supercar detail engineered for maximum excitement.",
+      "price": "R 1,719,022.90",
+      "image": "https://images.unsplash.com/photo-1502877338535-766e1452684a?q=80&w=1600&auto=format&fit=crop"
+    }
+  ],
+  "categories": [
+    { "name": "Sedans", "icon": "🚗" },
+    { "name": "SUVs", "icon": "🚙" },
+    { "name": "Coupes", "icon": "🏎️" },
+    { "name": "Trucks", "icon": "🚚" },
+    { "name": "Motorcycles", "icon": "🏍️" },
+    { "name": "Performance Parts", "icon": "⚙️" },
+    { "name": "Exterior", "icon": "✨" },
+    { "name": "Interior", "icon": "🧼" }
+  ],
+  "listings": [
+    { "id": "l1", "title": "Forged Alloy Racing Wheels (Set of 4)", "price": "R 49,114.94", "location": "Cape Town, South Africa", "condition": "New", "seller": "SpeedDemon Parts", "image": "https://images.unsplash.com/photo-1517677103901-1ff54b679d83?q=80&w=1600&auto=format&fit=crop" },
+    { "id": "l2", "title": "Recaro Sportster CS Seats (Pair)", "price": "R 26,311.58", "location": "Durban, South Africa", "condition": "Used - Excellent", "seller": "Trackday Gear", "image": "https://images.unsplash.com/photo-1571607388263-1044a2cc6621?q=80&w=1600&auto=format&fit=crop" },
+    { "id": "l3", "title": "Garrett GT35R Turbo Kit", "price": "R 21,049.26", "location": "Pretoria, South Africa", "condition": "Used - Good", "seller": "BoostUp Performance", "image": "https://images.unsplash.com/photo-1586297135537-94bc9ba060aa?q=80&w=1600&auto=format&fit=crop" },
+    { "id": "l4", "title": "Audi S5 OEM LED Headlights (Pair)", "price": "R 16,664.00", "location": "Johannesburg, South Africa", "condition": "New", "seller": "LuxuryCar Parts", "image": "https://images.unsplash.com/photo-1523986371872-9d3ba2e2f642?q=80&w=1600&auto=format&fit=crop" },
+    { "id": "l5", "title": "Borla Cat-Back Exhaust System", "price": "$780", "location": "Seattle, WA", "condition": "Used - Minor Scratches", "seller": "Soundwave Mods", "image": "https://images.unsplash.com/photo-1592853625600-9536c07a9a29?q=80&w=1600&auto=format&fit=crop" },
+    { "id": "l6", "title": "Carbon Fiber Rear Spoiler", "price": "R 7,839.47", "location": "Western Cape, South Africa", "condition": "New", "seller": "Aerodynamics", "image": "https://images.unsplash.com/photo-1619767886558-efdc259cde1b?q=80&w=1600&auto=format&fit=crop" },
+    { "id": "l7", "title": "Brembo GT Brake Kit Front", "price": "R 56,131.36", "location": "Johannesburg, South Africa", "condition": "Used - Good", "seller": "StreetSpec Racing", "image": "https://images.unsplash.com/photo-1503376780353-7e6692767b70?q=80&w=1600&auto=format&fit=crop" },
+    { "id": "l8", "title": "Ohlins Road & Track Coilovers", "price": "R 36,836.21", "location": "Pretoria, South Africa", "condition": "New", "seller": "RideComfort Tuning", "image": "https://images.unsplash.com/photo-1493238792000-8113da705763?q=80&w=1600&auto=format&fit=crop" },
+    { "id": "l9", "title": "MOMO Racing Steering Wheel", "price": "$300", "location": "Dallas, TX", "condition": "New", "seller": "GripEnhancers", "image": "https://images.unsplash.com/photo-1583121274602-3e2820c69888?q=80&w=1600&auto=format&fit=crop" },
+    { "id": "l10", "title": "Haltech Elite 2500 ECU", "price": "R 31,573.89", "location": "N/A", "condition": "New", "seller": "EngineLabs Tech", "image": "https://images.unsplash.com/photo-1465447142348-e9952c393450?q=80&w=1600&auto=format&fit=crop" },
+    { "id": "l11", "title": "BlackVue DR900X Plus Dashcam", "price": "R 6,139.37", "location": "Pretoria, South Africa", "condition": "New", "seller": "RoadGuard Safety", "image": "https://images.unsplash.com/photo-1562310500-1298e2ecb4de?q=80&w=1600&auto=format&fit=crop" },
+    { "id": "l12", "title": "JL Audio 12W6v3 Subwoofer", "price": "R 10,524.63", "location": "Western Cape, South Africa", "condition": "New", "seller": "Bassheads Audio", "image": "https://images.unsplash.com/photo-1512467651184-4542397173a0?q=80&w=1600&auto=format&fit=crop" }
+  ]
+}

--- a/autohub/frontend/src/pages/CommunityFeed.js
+++ b/autohub/frontend/src/pages/CommunityFeed.js
@@ -20,8 +20,54 @@ const CommunityFeed = () => {
         ]);
         if (!cancelled) {
           const postsData = Array.isArray(p.data) ? p.data : [];
-          setPosts(postsData);
-          setCommunityStats(Array.isArray(s.data) ? s.data : []);
+
+          // Fallback demo posts if API is empty
+          const fallbackPosts = [
+            {
+              id: 'demo-1',
+              author: 'Alex Carter',
+              avatar: 'https://i.pravatar.cc/96?img=12',
+              content: 'Just finished installing a new exhaust on my WRX. The sound is incredible! 🔧🔥',
+              image: 'https://images.unsplash.com/photo-1502877338535-766e1452684a?q=80&w=1200&auto=format&fit=crop',
+              likes: 128,
+              comments: 24,
+              featured: true,
+              timestamp: '2h ago'
+            },
+            {
+              id: 'demo-2',
+              author: 'Priya Singh',
+              avatar: 'https://i.pravatar.cc/96?img=32',
+              content: 'Detailing day! Any tips for keeping black paint swirl-free?',
+              image: 'https://images.unsplash.com/photo-1483721310020-03333e577078?q=80&w=1200&auto=format&fit=crop',
+              likes: 76,
+              comments: 11,
+              featured: false,
+              timestamp: '5h ago'
+            },
+            {
+              id: 'demo-3',
+              author: 'Marco Rossi',
+              avatar: 'https://i.pravatar.cc/96?img=15',
+              content: 'Spotted this classic 911 at the weekend meet. Absolute perfection.',
+              image: 'https://images.unsplash.com/photo-1503376780353-7e6692767b70?q=80&w=1200&auto=format&fit=crop',
+              likes: 211,
+              comments: 37,
+              featured: false,
+              timestamp: '1d ago'
+            }
+          ];
+
+          const normalizedPosts = postsData.length ? postsData : fallbackPosts;
+          setPosts(normalizedPosts);
+
+          const incomingStats = Array.isArray(s.data) ? s.data : [];
+          const fallbackStats = [
+            { value: '24.3k', label: 'Active Members', color: '#22C55E' },
+            { value: '182k', label: 'Total Posts', color: '#60A5FA' },
+            { value: '73', label: 'Upcoming Events', color: '#F59E0B' }
+          ];
+          setCommunityStats(incomingStats.length ? incomingStats : fallbackStats);
 
           // Normalize snapshots: accept array of strings or objects with `image` field
           let snapshots = Array.isArray(snaps.data) ? snaps.data : [];
@@ -33,10 +79,20 @@ const CommunityFeed = () => {
 
           // Fallback to images from posts if API returns nothing
           if (!snapshots.length) {
-            snapshots = postsData
+            const source = normalizedPosts
               .filter((post) => post && post.image)
               .slice(0, 9)
               .map((post) => ({ id: post.id, image: post.image, alt: post.content }));
+            snapshots = source;
+          }
+
+          // If still empty, provide static snapshots
+          if (!snapshots.length) {
+            snapshots = [
+              { id: 'snap-1', image: 'https://images.unsplash.com/photo-1511919884226-fd3cad34687c?q=80&w=1200&auto=format&fit=crop' },
+              { id: 'snap-2', image: 'https://images.unsplash.com/photo-1519580930-4f119914eec8?q=80&w=1200&auto=format&fit=crop' },
+              { id: 'snap-3', image: 'https://images.unsplash.com/photo-1503736334956-4c8f8e92946d?q=80&w=1200&auto=format&fit=crop' }
+            ];
           }
           setCommunitySnapshots(snapshots);
         }

--- a/autohub/frontend/src/pages/CommunityFeed.js
+++ b/autohub/frontend/src/pages/CommunityFeed.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import Header from '../components/Header';
+import communityData from '../data/community.json';
 import './CommunityFeed.css';
 
 const CommunityFeed = () => {
@@ -21,52 +22,12 @@ const CommunityFeed = () => {
         if (!cancelled) {
           const postsData = Array.isArray(p.data) ? p.data : [];
 
-          // Fallback demo posts if API is empty
-          const fallbackPosts = [
-            {
-              id: 'demo-1',
-              author: 'Alex Carter',
-              avatar: 'https://i.pravatar.cc/96?img=12',
-              content: 'Just finished installing a new exhaust on my WRX. The sound is incredible! 🔧🔥',
-              image: 'https://images.unsplash.com/photo-1502877338535-766e1452684a?q=80&w=1200&auto=format&fit=crop',
-              likes: 128,
-              comments: 24,
-              featured: true,
-              timestamp: '2h ago'
-            },
-            {
-              id: 'demo-2',
-              author: 'Priya Singh',
-              avatar: 'https://i.pravatar.cc/96?img=32',
-              content: 'Detailing day! Any tips for keeping black paint swirl-free?',
-              image: 'https://images.unsplash.com/photo-1483721310020-03333e577078?q=80&w=1200&auto=format&fit=crop',
-              likes: 76,
-              comments: 11,
-              featured: false,
-              timestamp: '5h ago'
-            },
-            {
-              id: 'demo-3',
-              author: 'Marco Rossi',
-              avatar: 'https://i.pravatar.cc/96?img=15',
-              content: 'Spotted this classic 911 at the weekend meet. Absolute perfection.',
-              image: 'https://images.unsplash.com/photo-1503376780353-7e6692767b70?q=80&w=1200&auto=format&fit=crop',
-              likes: 211,
-              comments: 37,
-              featured: false,
-              timestamp: '1d ago'
-            }
-          ];
-
-          const normalizedPosts = postsData.length ? postsData : fallbackPosts;
+          // Use imported static dataset as fallback
+          const normalizedPosts = postsData.length ? postsData : (communityData.posts || []);
           setPosts(normalizedPosts);
 
           const incomingStats = Array.isArray(s.data) ? s.data : [];
-          const fallbackStats = [
-            { value: '24.3k', label: 'Active Members', color: '#22C55E' },
-            { value: '182k', label: 'Total Posts', color: '#60A5FA' },
-            { value: '73', label: 'Upcoming Events', color: '#F59E0B' }
-          ];
+          const fallbackStats = communityData.stats || [];
           setCommunityStats(incomingStats.length ? incomingStats : fallbackStats);
 
           // Normalize snapshots: accept array of strings or objects with `image` field

--- a/autohub/frontend/src/pages/ListingDetails.js
+++ b/autohub/frontend/src/pages/ListingDetails.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { useParams } from 'react-router-dom';
 import Header from '../components/Header';
+import listingStatic from '../data/listingDetails.json';
 import './ListingDetails.css';
 
 const ListingDetails = () => {
@@ -21,7 +22,10 @@ const ListingDetails = () => {
           axios.get(`/api/listings/${id}/related`)
         ]);
         if (!cancelled) {
-          const info = d.data || {};
+          const fallback = listingStatic.listing || {};
+          const infoRaw = d.data || {};
+          const info = (infoRaw && Object.keys(infoRaw).length) ? infoRaw : fallback;
+
           setDetails({
             title: info.title || '',
             price: info.price || '',
@@ -29,16 +33,19 @@ const ListingDetails = () => {
             tags: info.tags || [],
             location: info.location || ''
           });
-          setVehicleImages(Array.isArray(info.images) ? info.images : []);
-          setVehicleSpecs(Array.isArray(info.specs) ? info.specs : []);
-          setRelatedListings(Array.isArray(r.data) ? r.data : []);
+          setVehicleImages(Array.isArray(info.images) && info.images.length ? info.images : (fallback.images || []));
+          setVehicleSpecs(Array.isArray(info.specs) && info.specs.length ? info.specs : (fallback.specs || []));
+
+          const rData = Array.isArray(r.data) && r.data.length ? r.data : (listingStatic.related || []);
+          setRelatedListings(rData);
         }
       } catch (e) {
         if (!cancelled) {
-          setVehicleImages([]);
-          setVehicleSpecs([]);
-          setRelatedListings([]);
-          setDetails({ title: '', price: '', description: '', tags: [], location: '' });
+          const fb = listingStatic.listing || {};
+          setVehicleImages(fb.images || []);
+          setVehicleSpecs(fb.specs || []);
+          setRelatedListings(listingStatic.related || []);
+          setDetails({ title: fb.title || '', price: fb.price || '', description: fb.description || '', tags: fb.tags || [], location: fb.location || '' });
         }
       }
     };

--- a/autohub/frontend/src/pages/Marketplace.js
+++ b/autohub/frontend/src/pages/Marketplace.js
@@ -28,9 +28,67 @@ const Marketplace = () => {
           axios.get('/api/listings')
         ]);
         if (!cancelled) {
-          setFeaturedListings(Array.isArray(f.data) ? f.data : []);
-          setCategories(Array.isArray(c.data) ? c.data : []);
-          setAllListings(Array.isArray(a.data) ? a.data : []);
+          const incomingFeatured = Array.isArray(f.data) ? f.data : [];
+          const incomingCategories = Array.isArray(c.data) ? c.data : [];
+          const incomingListings = Array.isArray(a.data) ? a.data : [];
+
+          const fallbackFeatured = [
+            {
+              id: 'fl-1',
+              title: '2019 BMW M2 Competition',
+              description: 'Low miles, pristine condition, performance pack.',
+              price: '$52,900',
+              image: 'https://images.unsplash.com/photo-1555215695-3004980ad54e?q=80&w=1200&auto=format&fit=crop'
+            },
+            {
+              id: 'fl-2',
+              title: 'Toyota GR Yaris',
+              description: 'Stage 1 tune, forged wheels, immaculate.',
+              price: '$38,400',
+              image: 'https://images.unsplash.com/photo-1619523440439-89143c4eb1b5?q=80&w=1200&auto=format&fit=crop'
+            }
+          ];
+
+          const fallbackCategories = [
+            { name: 'cars', icon: '🚗' },
+            { name: 'parts', icon: '🔧' },
+            { name: 'accessories', icon: '🧰' },
+            { name: 'wheels', icon: '🛞' }
+          ];
+
+          const fallbackListings = [
+            {
+              id: 'al-1',
+              title: 'Audi S4 B9',
+              price: '$27,500',
+              location: 'San Diego, CA',
+              condition: 'Used - Excellent',
+              seller: 'alex_c',
+              image: 'https://images.unsplash.com/photo-1515923162063-5a5b89c57cde?q=80&w=1200&auto=format&fit=crop'
+            },
+            {
+              id: 'al-2',
+              title: 'HKS Blow Off Valve',
+              price: '$180',
+              location: 'Austin, TX',
+              condition: 'Used - Good',
+              seller: 'marco_r',
+              image: 'https://images.unsplash.com/photo-1571769199112-3a88f66f2827?q=80&w=1200&auto=format&fit=crop'
+            },
+            {
+              id: 'al-3',
+              title: 'Ford Mustang GT 5.0',
+              price: '$31,900',
+              location: 'Orlando, FL',
+              condition: 'Used - Excellent',
+              seller: 'priya_s',
+              image: 'https://images.unsplash.com/photo-1504215680853-026ed2a45def?q=80&w=1200&auto=format&fit=crop'
+            }
+          ];
+
+          setFeaturedListings(incomingFeatured.length ? incomingFeatured : fallbackFeatured);
+          setCategories(incomingCategories.length ? incomingCategories : fallbackCategories);
+          setAllListings(incomingListings.length ? incomingListings : fallbackListings);
         }
       } catch (e) {
         if (!cancelled) {

--- a/autohub/frontend/src/pages/Marketplace.js
+++ b/autohub/frontend/src/pages/Marketplace.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 import Header from '../components/Header';
+import marketplaceData from '../data/marketplace.json';
 import './Marketplace.css';
 
 const Marketplace = () => {
@@ -32,59 +33,9 @@ const Marketplace = () => {
           const incomingCategories = Array.isArray(c.data) ? c.data : [];
           const incomingListings = Array.isArray(a.data) ? a.data : [];
 
-          const fallbackFeatured = [
-            {
-              id: 'fl-1',
-              title: '2019 BMW M2 Competition',
-              description: 'Low miles, pristine condition, performance pack.',
-              price: '$52,900',
-              image: 'https://images.unsplash.com/photo-1555215695-3004980ad54e?q=80&w=1200&auto=format&fit=crop'
-            },
-            {
-              id: 'fl-2',
-              title: 'Toyota GR Yaris',
-              description: 'Stage 1 tune, forged wheels, immaculate.',
-              price: '$38,400',
-              image: 'https://images.unsplash.com/photo-1619523440439-89143c4eb1b5?q=80&w=1200&auto=format&fit=crop'
-            }
-          ];
-
-          const fallbackCategories = [
-            { name: 'cars', icon: '🚗' },
-            { name: 'parts', icon: '🔧' },
-            { name: 'accessories', icon: '🧰' },
-            { name: 'wheels', icon: '🛞' }
-          ];
-
-          const fallbackListings = [
-            {
-              id: 'al-1',
-              title: 'Audi S4 B9',
-              price: '$27,500',
-              location: 'San Diego, CA',
-              condition: 'Used - Excellent',
-              seller: 'alex_c',
-              image: 'https://images.unsplash.com/photo-1515923162063-5a5b89c57cde?q=80&w=1200&auto=format&fit=crop'
-            },
-            {
-              id: 'al-2',
-              title: 'HKS Blow Off Valve',
-              price: '$180',
-              location: 'Austin, TX',
-              condition: 'Used - Good',
-              seller: 'marco_r',
-              image: 'https://images.unsplash.com/photo-1571769199112-3a88f66f2827?q=80&w=1200&auto=format&fit=crop'
-            },
-            {
-              id: 'al-3',
-              title: 'Ford Mustang GT 5.0',
-              price: '$31,900',
-              location: 'Orlando, FL',
-              condition: 'Used - Excellent',
-              seller: 'priya_s',
-              image: 'https://images.unsplash.com/photo-1504215680853-026ed2a45def?q=80&w=1200&auto=format&fit=crop'
-            }
-          ];
+          const fallbackFeatured = (marketplaceData.featured || []);
+          const fallbackCategories = (marketplaceData.categories || []);
+          const fallbackListings = (marketplaceData.listings || []);
 
           setFeaturedListings(incomingFeatured.length ? incomingFeatured : fallbackFeatured);
           setCategories(incomingCategories.length ? incomingCategories : fallbackCategories);


### PR DESCRIPTION
## Purpose
The user requested to repopulate the community page and marketplace page with static data while preserving any new code. They specifically wanted the static data that was previously available on these pages to be restored as fallback content.

## Code changes
- **Added static data files**: Created `community.json`, `marketplace.json`, and `listingDetails.json` in the `src/data/` directory containing sample posts, listings, categories, and vehicle specifications
- **Implemented fallback logic**: Modified `CommunityFeed.js`, `Marketplace.js`, and `ListingDetails.js` to use static data when API responses are empty or unavailable
- **Enhanced data handling**: Added proper data validation and fallback mechanisms to ensure pages display content even when backend APIs return no data
- **Preserved existing functionality**: All new code and API integration remains intact, with static data serving as backup content onlyTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/266cc1eec07840d99d3a6cca6a54b26f/spark-sanctuary)

👀 [Preview Link](https://266cc1eec07840d99d3a6cca6a54b26f-spark-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>266cc1eec07840d99d3a6cca6a54b26f</projectId>-->
<!--<branchName>spark-sanctuary</branchName>-->